### PR TITLE
Remove skip for scenes already in stash

### DIFF
--- a/SHALookup.py
+++ b/SHALookup.py
@@ -231,9 +231,6 @@ def scrape():
         log.error("Scene not found - check your config.py file")
         sys.exit(1)
     # log.debug(scene)
-    if len(scene['stash_ids']) > 0:
-        log.debug("Already in stash, skipping")
-        return None
     alltags = [tag["id"] for tag in scene["tags"]]
     if nomatch_id in alltags or success_id in alltags:
         log.debug("Already searched, skipping")


### PR DESCRIPTION
> although it can probably be removed now that it has sha cache

I don't see a sha cache anywhere but I believe you.

Having it skip is confusing when trying to manually update. For instance if the scene has a stash id for a different stash box, or if intending to correct data from coomer.