### PR TITLE
Constant should be capitalized, throwing error

### DIFF
--- a/plugins/SHALookup/config.py.example
+++ b/plugins/SHALookup/config.py.example
@@ -6,4 +6,4 @@ stashconfig = {
 }
 success_tag = "[SHA: Scraped]"
 failure_tag = "[SHA: No Match]"
-disable_nfkd = false
+disable_nfkd = False


### PR DESCRIPTION
This throws an error in Python 3.11.8

```
[Scrape / SHA256 Lookup] NameError: name 'false' is not defined. Did you mean: 'False'?
[Scrape / SHA256 Lookup]                    ^^^^^
[Scrape / SHA256 Lookup]     disable_nfkd = false
[Scrape / SHA256 Lookup]   File "/root/.stash/scrapers/fansdb/SHALookup/config.py", line 9, in <module>
```