### PR TITLE
Fixing Scraper

### DIFF
--- a/plugins/SHALookup/SHALookup.py
+++ b/plugins/SHALookup/SHALookup.py
@@ -108,6 +108,7 @@ def getPostByHash(hash):
         log.error(f"Request failed with status code {postres.status}")
         sys.exit(1)
     scene = postres.json()
+    scene = scene["post"]
     return splitLookup(scene, hash)
 
 def splitLookup(scene, hash):
@@ -206,16 +207,12 @@ def getnamefromalias(alias):
     return alias
 
 def getFanslyUsername(id):
-    res = requests.get(f"https://coomer.su/fansly/user/{id}", headers=headers)
+    res = requests.get(f"https://coomer.su/api/v1/fansly/user/{id}/profile", headers=headers)
     if not res.status_code == 200:
         log.error(f"Request failed with status code {res.status}")
         sys.exit(1)
-    tree = html.fromstring(res.text)
-    userbox = tree.xpath('//*[@id="user-header__info-top"]/a/span[2]')
-    if (len(userbox) == 0):
-        log.error("No user found for id " + id)
-        return None
-    return userbox[0].text
+    profile = res.json()
+    return profile["name"]
 
 # if fansly
 def parseFansly(scene, hash):


### PR DESCRIPTION
It looks like the `search_hash` endpoint changed the response.

To easily adjust to this I just updated the `scene` variable to be the value of the `scene["post"]` key, which appears to be what we used to expect.

Additionally I had to update `getFanslyUsername` to hit the profile API endpoint instead of just scraping the webpage as we were no longer getting the proper response.